### PR TITLE
Feature/initial

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,14 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/tabi/appuser/controller/AppUserController.java
+++ b/src/main/java/com/example/tabi/appuser/controller/AppUserController.java
@@ -1,0 +1,30 @@
+package com.example.tabi.appuser.controller;
+
+import com.example.tabi.appuser.entity.AppUser;
+import com.example.tabi.appuser.service.AppUserService;
+import com.example.tabi.appuser.vo.AppUserDto;
+import com.example.tabi.appuser.vo.AppUserRequest;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/app-user")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "AppUser", description = "유저 관련 API")
+public class AppUserController {
+    private final AppUserService appUserService;
+
+    @PostMapping("/initial/users")
+    public ResponseEntity<?> createUser(@RequestBody AppUserRequest appUserRequest) {
+        log.info("Agreement {}", appUserRequest.isAgreement());
+        AppUserDto appUserDto = appUserService.createAppUser(appUserRequest);
+        return ResponseEntity.ok(appUserDto);
+    }
+}

--- a/src/main/java/com/example/tabi/appuser/entity/AppUser.java
+++ b/src/main/java/com/example/tabi/appuser/entity/AppUser.java
@@ -1,0 +1,32 @@
+package com.example.tabi.appuser.entity;
+
+import com.example.tabi.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+public class AppUser {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long appUserId;
+    private String username;
+    private LocalDateTime birth;
+    // true: 남성, false: 여성
+    private boolean gender;
+    private String mobileCarrier;
+    private String phoneNumber;
+    private boolean agreement;
+    private boolean locked;
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @OneToOne(mappedBy = "appUser", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    private Member member;
+}

--- a/src/main/java/com/example/tabi/appuser/repository/AppUserRepository.java
+++ b/src/main/java/com/example/tabi/appuser/repository/AppUserRepository.java
@@ -1,0 +1,10 @@
+package com.example.tabi.appuser.repository;
+
+import com.example.tabi.appuser.entity.AppUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AppUserRepository extends JpaRepository<AppUser, Long> {
+    AppUser findByAppUserId(Long appUserId);
+}

--- a/src/main/java/com/example/tabi/appuser/service/AppUserService.java
+++ b/src/main/java/com/example/tabi/appuser/service/AppUserService.java
@@ -1,0 +1,17 @@
+package com.example.tabi.appuser.service;
+
+import com.example.tabi.appuser.vo.AppUserDto;
+import com.example.tabi.appuser.vo.AppUserRequest;
+import com.example.tabi.appuser.vo.RedundancyCheckRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+public interface AppUserService {
+    AppUserDto createAppUser(AppUserRequest appUserRequest);
+    AppUserDto getAppUser(Authentication authentication);
+    AppUserDto updateAppUser(Authentication authentication, AppUserRequest appUserRequest);
+    void deleteAppUser(Authentication authentication);
+
+    Boolean emailRedundancyCheck(RedundancyCheckRequest redundancyCheckRequest);
+    Boolean phoneNumberRedundancyCheck(RedundancyCheckRequest redundancyCheckRequest);
+}

--- a/src/main/java/com/example/tabi/appuser/service/AppUserServiceJpaImpl.java
+++ b/src/main/java/com/example/tabi/appuser/service/AppUserServiceJpaImpl.java
@@ -1,0 +1,82 @@
+package com.example.tabi.appuser.service;
+
+import com.example.tabi.appuser.entity.AppUser;
+import com.example.tabi.appuser.repository.AppUserRepository;
+import com.example.tabi.appuser.vo.AppUserDto;
+import com.example.tabi.appuser.vo.AppUserRequest;
+import com.example.tabi.appuser.vo.RedundancyCheckRequest;
+import com.example.tabi.member.entity.Member;
+import com.example.tabi.member.repository.MemberRepository;
+import com.example.tabi.member.vo.MemberDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AppUserServiceJpaImpl implements AppUserService {
+    private final AppUserRepository appUserRepository;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public AppUserDto createAppUser(AppUserRequest appUserRequest) {
+        AppUser appUser = new AppUser();
+        appUser.setUsername(appUserRequest.getUsername());
+        appUser.setBirth(appUserRequest.getBirth());
+        appUser.setGender(appUserRequest.isGender());
+        appUser.setMobileCarrier(appUserRequest.getMobileCarrier());
+        appUser.setPhoneNumber(appUserRequest.getPhoneNumber());
+        log.info("Agreement : {}", appUserRequest.isAgreement());
+        System.out.println(appUserRequest.isAgreement());
+        appUser.setAgreement(appUserRequest.isAgreement());
+        appUser.setLocked(false);
+
+        Member member = new Member();
+        member.setEmail(appUserRequest.getEmail());
+        member.setPassword(passwordEncoder.encode(appUserRequest.getPassword()));
+
+        appUser.setMember(member);
+        member.setAppUser(appUser);
+
+        appUserRepository.save(appUser);
+        memberRepository.save(member);
+
+        return appUserToAppUserDto(appUser);
+    }
+
+    @Override
+    public AppUserDto getAppUser(Authentication authentication) {
+        return null;
+    }
+
+    @Override
+    public AppUserDto updateAppUser(Authentication authentication, AppUserRequest appUserRequest) {
+        return null;
+    }
+
+    @Override
+    public void deleteAppUser(Authentication authentication) {
+
+    }
+
+    @Override
+    public Boolean phoneNumberRedundancyCheck(RedundancyCheckRequest redundancyCheckRequest) {
+        return null;
+    }
+
+    @Override
+    public Boolean emailRedundancyCheck(RedundancyCheckRequest redundancyCheckRequest) {
+        return null;
+    }
+
+    public static AppUserDto appUserToAppUserDto(AppUser appUser) {
+        MemberDto memberDto = new  MemberDto(appUser.getMember().getMemberId(), appUser.getMember().getEmail(), appUser.getMember().getPassword());
+        AppUserDto appUserDto = new AppUserDto(appUser.getAppUserId(), appUser.getUsername(), appUser.getBirth(), appUser.isGender(), appUser.getMobileCarrier(), appUser.getPhoneNumber(), appUser.isAgreement(), appUser.isLocked(), appUser.getCreatedAt(), appUser.getUpdatedAt(), memberDto);
+
+        return appUserDto;
+    }
+}

--- a/src/main/java/com/example/tabi/appuser/vo/AppUserDto.java
+++ b/src/main/java/com/example/tabi/appuser/vo/AppUserDto.java
@@ -1,0 +1,32 @@
+package com.example.tabi.appuser.vo;
+
+import com.example.tabi.member.vo.MemberDto;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppUserDto {
+    private Long appUserId;
+    private String username;
+    private LocalDateTime birth;
+    private boolean gender;
+    private String mobileCarrier;
+    private String phoneNumber;
+    private boolean agreement;
+    private boolean locked;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    private MemberDto memberDto;
+}

--- a/src/main/java/com/example/tabi/appuser/vo/AppUserRequest.java
+++ b/src/main/java/com/example/tabi/appuser/vo/AppUserRequest.java
@@ -1,0 +1,18 @@
+package com.example.tabi.appuser.vo;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class AppUserRequest {
+    private String username;
+    private LocalDateTime birth;
+    private boolean gender;
+    private String mobileCarrier;
+    private String phoneNumber;
+    private boolean agreement;
+
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/example/tabi/appuser/vo/RedundancyCheckRequest.java
+++ b/src/main/java/com/example/tabi/appuser/vo/RedundancyCheckRequest.java
@@ -1,0 +1,9 @@
+package com.example.tabi.appuser.vo;
+
+import lombok.Data;
+
+@Data
+public class RedundancyCheckRequest {
+    String email;
+    String phoneNumber;
+}

--- a/src/main/java/com/example/tabi/config/CorsConfig.java
+++ b/src/main/java/com/example/tabi/config/CorsConfig.java
@@ -1,0 +1,26 @@
+package com.example.tabi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.filter.CorsFilter;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsConfig {
+    @Bean
+    public CorsFilter corsFilter() {
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+        corsConfiguration.addAllowedOriginPattern("*");
+        corsConfiguration.addAllowedHeader("*");
+        corsConfiguration.addAllowedMethod("*");
+        //JWT 쿠키기반 사용
+        corsConfiguration.setAllowCredentials(true);
+        corsConfiguration.addExposedHeader("Authorization");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", corsConfiguration);
+
+        return new CorsFilter(source);
+    }
+}

--- a/src/main/java/com/example/tabi/config/SecurityConfig.java
+++ b/src/main/java/com/example/tabi/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.example.tabi.config;
 
 import com.example.tabi.login.*;
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -28,11 +27,11 @@ public class SecurityConfig{
                         .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/v3/api-docs").permitAll()
                         .requestMatchers("/error").permitAll()
                         //.requestMatchers(PathRequest.toH2Console()).permitAll()
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/auth/login", "api/auth/refresh").permitAll()
                         .anyRequest().authenticated()
 
-        ).addFilter(new JwtAuthenticationFilter(authenticationManager, jwtUtil, refreshTokenService))
-                .addFilterBefore(new JwtAuthorizationFilter(jwtUtil, customUserDetailsService), JwtAuthenticationFilter.class);
+        ).addFilter(new UsernamePasswordJwtLoginFilter(authenticationManager, jwtUtil, refreshTokenService))
+                .addFilterBefore(new JwtVerificationFilter(jwtUtil, customUserDetailsService), UsernamePasswordJwtLoginFilter.class);
         http.headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()));
 
         return http.build();

--- a/src/main/java/com/example/tabi/config/SecurityConfig.java
+++ b/src/main/java/com/example/tabi/config/SecurityConfig.java
@@ -1,0 +1,50 @@
+package com.example.tabi.config;
+
+import com.example.tabi.login.*;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig{
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationManager authenticationManager, JwtUtil jwtUtil, RefreshTokenService refreshTokenService, CustomUserDetailsService customUserDetailsService) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable);
+        http.cors(Customizer.withDefaults());
+
+        http.authorizeHttpRequests(authorizeRequests ->
+                authorizeRequests.requestMatchers("/api/app-user/initial/**").permitAll()
+                        .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/v3/api-docs").permitAll()
+                        .requestMatchers("/error").permitAll()
+                        //.requestMatchers(PathRequest.toH2Console()).permitAll()
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated()
+
+        ).addFilter(new JwtAuthenticationFilter(authenticationManager, jwtUtil, refreshTokenService))
+                .addFilterBefore(new JwtAuthorizationFilter(jwtUtil, customUserDetailsService), JwtAuthenticationFilter.class);
+        http.headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()));
+
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/tabi/login/CustomUserDetails.java
+++ b/src/main/java/com/example/tabi/login/CustomUserDetails.java
@@ -1,0 +1,35 @@
+package com.example.tabi.login;
+
+import com.example.tabi.appuser.entity.AppUser;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+    private final Long appUserId;
+    private final String email;
+    private final String password;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public CustomUserDetails(AppUser appUser) {
+        this.appUserId = appUser.getAppUserId();
+        this.email = appUser.getMember().getEmail();
+        this.password = appUser.getMember().getPassword();
+        this.authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.email;
+    }
+}

--- a/src/main/java/com/example/tabi/login/CustomUserDetailsService.java
+++ b/src/main/java/com/example/tabi/login/CustomUserDetailsService.java
@@ -1,0 +1,34 @@
+package com.example.tabi.login;
+
+import com.example.tabi.appuser.entity.AppUser;
+import com.example.tabi.appuser.repository.AppUserRepository;
+import com.example.tabi.member.entity.Member;
+import com.example.tabi.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final AppUserRepository appUserRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email);
+
+        if (member == null) {
+            throw new UsernameNotFoundException("회원을 찾을 수 없습니다: " + email);
+        }
+
+        AppUser appUser = member.getAppUser();
+        if (appUser == null) {
+            throw new UsernameNotFoundException("AppUser 정보가 없습니다: " + email);
+        }
+
+        return new CustomUserDetails(appUser);
+    }
+}

--- a/src/main/java/com/example/tabi/login/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/tabi/login/JwtAuthenticationFilter.java
@@ -1,0 +1,67 @@
+package com.example.tabi.login;
+
+import com.example.tabi.login.vo.LoginRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenService refreshTokenService;
+
+     public JwtAuthenticationFilter(AuthenticationManager authManager,
+                                   JwtUtil jwtUtil,
+                                   RefreshTokenService refreshSvc) {
+        this.authenticationManager = authManager;
+        this.jwtUtil = jwtUtil;
+        this.refreshTokenService = refreshSvc;
+
+        setFilterProcessesUrl("/api/auth/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        try {
+            LoginRequest loginRequest = new ObjectMapper().readValue(request.getInputStream(), LoginRequest.class);
+            UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(loginRequest.getEmail(), loginRequest.getPassword());
+            return authenticationManager.authenticate(token);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
+        String email = ((CustomUserDetails) authResult.getPrincipal()).getEmail();
+        String accessToken = jwtUtil.generateAccessToken(email);
+        String refreshToken = jwtUtil.generateRefreshToken(email);
+
+        refreshTokenService.createOrUpdateToken(email, refreshToken);
+
+        response.setHeader("Authorization", "Bearer " + accessToken);
+
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .maxAge(7 * 24 * 60 * 60)
+                .build();
+
+        response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+}

--- a/src/main/java/com/example/tabi/login/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/tabi/login/JwtAuthorizationFilter.java
@@ -1,0 +1,73 @@
+package com.example.tabi.login;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String path = request.getRequestURI();
+
+        AntPathMatcher pathMatcher = new AntPathMatcher();
+
+        return pathMatcher.match("/api/auth/**", path) || pathMatcher.match("/api/app-user/initial/**", path);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+
+        if(header == null || !header.startsWith("Bearer ")){
+            // access 토큰이 없는 경우
+            filterChain.doFilter(request,response);
+            return;
+        }
+
+        String token = header.replace("Bearer ", "");
+        String email;
+        try {
+            email = jwtUtil.extractAccessTokenLoginId(token);
+        } catch (ExpiredJwtException e) {
+            log.info("엑세스 토큰 만료");
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Expiration Token");
+            return;
+        } catch (JwtException e) {
+            log.info("유효하지 않은 토큰");
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid Token");
+            return;
+        }
+
+
+        if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            CustomUserDetails customUserDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(email);
+
+            log.info("customUserDetails:{}",customUserDetails);
+
+            if (jwtUtil.validateAccessToken(token, customUserDetails)) {
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                log.info("Authentication:{}",authentication);
+            }
+        }
+
+        filterChain.doFilter(request,response);
+    }
+}

--- a/src/main/java/com/example/tabi/login/JwtUtil.java
+++ b/src/main/java/com/example/tabi/login/JwtUtil.java
@@ -1,0 +1,94 @@
+package com.example.tabi.login;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Date;
+
+@Component
+@Getter
+public class JwtUtil {
+    @Value("${jwt.access.secret.key}")
+    private String ACCESS_SECRET_KEY;
+    @Value("${jwt.refresh.secret.key}")
+    private String REFRESH_SECRET_KEY;
+    private final Long ACCESS_EXP = Duration.ofMinutes(15).toMillis();
+    private final Long REFRESH_EXP = Duration.ofDays(7).toMillis();
+
+    public String generateAccessToken(String email) {
+        Date now = new Date();
+
+        return Jwts.builder()
+                .subject(email)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + ACCESS_EXP))
+                .signWith(Keys.hmacShaKeyFor(ACCESS_SECRET_KEY.getBytes()))
+                .compact();
+    }
+
+    public String extractAccessTokenLoginId(String accessToken) {
+        return Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(ACCESS_SECRET_KEY.getBytes()))
+                .build()
+                .parseSignedClaims(accessToken)
+                .getPayload()
+                .getSubject();
+    }
+
+    public boolean validateAccessToken(String accessToken, CustomUserDetails customUserDetails) {
+        String email = extractAccessTokenLoginId(accessToken);
+        Date exp = Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(ACCESS_SECRET_KEY.getBytes()))
+                .build()
+                .parseSignedClaims(accessToken)
+                .getPayload()
+                .getExpiration();
+         return email.equals(customUserDetails.getEmail()) && exp.after(new Date());
+    }
+
+    public boolean isAccessTokenExpired(String accessToken) {
+        Date exp = Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(ACCESS_SECRET_KEY.getBytes()))
+                .build()
+                .parseSignedClaims(accessToken)
+                .getPayload()
+                .getExpiration();
+        return exp.before(new Date());
+    }
+
+    public String generateRefreshToken(String email) {
+        Date now = new Date();
+
+        return Jwts.builder()
+                .subject(email)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + ACCESS_EXP))
+                .signWith(Keys.hmacShaKeyFor(REFRESH_SECRET_KEY.getBytes()))
+                .compact();
+    }
+
+    public String extractRefreshTokenLoginId(String refreshToken) {
+        return Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(REFRESH_SECRET_KEY.getBytes()))
+                .build()
+                .parseSignedClaims(refreshToken)
+                .getPayload()
+                .getSubject();
+    }
+
+    // 리프레시 토큰은 항상 서버에서 관리하기 때문에 조작 위협은 적다. (서버가 해킹당하지 않는 이상)
+    // 따라서 굳이 유효성검사 함수를 빼기보단 기간 만료 되었는지 먼저 확인하자.
+    public boolean isRefreshTokenExpired(String refreshToken) {
+        Date exp = Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(REFRESH_SECRET_KEY.getBytes()))
+                .build()
+                .parseSignedClaims(refreshToken)
+                .getPayload()
+                .getExpiration();
+        return exp.before(new Date());
+    }
+}

--- a/src/main/java/com/example/tabi/login/JwtVerificationFilter.java
+++ b/src/main/java/com/example/tabi/login/JwtVerificationFilter.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 
 @RequiredArgsConstructor
 @Slf4j
-public class JwtAuthorizationFilter extends OncePerRequestFilter {
+public class JwtVerificationFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
     private final CustomUserDetailsService customUserDetailsService;
 
@@ -36,7 +36,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
         if(header == null || !header.startsWith("Bearer ")){
             // access 토큰이 없는 경우
-            filterChain.doFilter(request,response);
+            filterChain.doFilter(request,response); // -> UsernamePasswordJwtLoginFilter로 넘어가
             return;
         }
 
@@ -53,7 +53,6 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid Token");
             return;
         }
-
 
         if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
             CustomUserDetails customUserDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(email);

--- a/src/main/java/com/example/tabi/login/RefreshToken.java
+++ b/src/main/java/com/example/tabi/login/RefreshToken.java
@@ -1,0 +1,24 @@
+package com.example.tabi.login;
+
+import com.example.tabi.appuser.entity.AppUser;
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Entity
+@Data
+public class RefreshToken {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long refreshTokenId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "app_user_id")
+    private AppUser appUser;
+
+    @Column(nullable = false, unique = true)
+    private String refreshToken;
+
+    @Column(nullable = false)
+    private Instant expiryDate;
+}

--- a/src/main/java/com/example/tabi/login/RefreshTokenRepository.java
+++ b/src/main/java/com/example/tabi/login/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package com.example.tabi.login;
+
+import com.example.tabi.appuser.entity.AppUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByAppUser(AppUser appUser);
+    RefreshToken findByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/example/tabi/login/RefreshTokenService.java
+++ b/src/main/java/com/example/tabi/login/RefreshTokenService.java
@@ -1,0 +1,62 @@
+package com.example.tabi.login;
+
+import com.example.tabi.appuser.entity.AppUser;
+import com.example.tabi.appuser.repository.AppUserRepository;
+import com.example.tabi.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final AppUserRepository appUserRepository;
+    private final MemberRepository memberRepository;
+    private static final Integer MAX_DAYS = 1;
+
+    public void createOrUpdateToken(String email, String refreshToken) {
+        AppUser appUser = appUserRepository.findByAppUserId(memberRepository.findByEmail(email).getAppUser().getAppUserId());
+        Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findByAppUser(appUser);
+
+        //Instant now = Instant.now();
+        //Instant newExpiryDate = now.plus(7, ChronoUnit.DAYS);
+
+        if (optionalRefreshToken.isEmpty()) {
+            RefreshToken newRefreshToken = new RefreshToken();
+            newRefreshToken.setAppUser(appUser);
+            newRefreshToken.setRefreshToken(refreshToken);
+            newRefreshToken.setExpiryDate(Instant.now().plus(7, ChronoUnit.DAYS));
+
+            refreshTokenRepository.save(newRefreshToken);
+        } else {
+            //long daysLeft = ChronoUnit.DAYS.between(now, optionalRefreshToken.get().getExpiryDate());
+
+            optionalRefreshToken.get().setRefreshToken(refreshToken);
+            optionalRefreshToken.get().setExpiryDate(Instant.now().plus(7, ChronoUnit.DAYS));
+
+            refreshTokenRepository.save(optionalRefreshToken.get());
+        }
+    }
+
+    public AppUser validateRefreshToken(String refreshToken) {
+        RefreshToken checkRefreshToken = refreshTokenRepository.findByRefreshToken(refreshToken);
+
+        if (checkRefreshToken == null)
+            return null;
+
+        if (checkRefreshToken.getExpiryDate().isAfter(Instant.now())) {
+            return refreshTokenRepository.findByRefreshToken(refreshToken).getAppUser();
+        }
+
+        return null;
+    }
+
+    public void deleteByRefreshToken(String refreshToken) {
+        RefreshToken targetRefreshToken = refreshTokenRepository.findByRefreshToken(refreshToken);
+        refreshTokenRepository.delete(targetRefreshToken);
+    }
+}

--- a/src/main/java/com/example/tabi/login/RefreshTokenService.java
+++ b/src/main/java/com/example/tabi/login/RefreshTokenService.java
@@ -3,7 +3,11 @@ package com.example.tabi.login;
 import com.example.tabi.appuser.entity.AppUser;
 import com.example.tabi.appuser.repository.AppUserRepository;
 import com.example.tabi.member.repository.MemberRepository;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -13,33 +17,30 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class RefreshTokenService {
+    private final JwtUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository;
     private final AppUserRepository appUserRepository;
     private final MemberRepository memberRepository;
     private static final Integer MAX_DAYS = 1;
 
-    public void createOrUpdateToken(String email, String refreshToken) {
+    // Refresh Token 서버 저장
+    // 로그인 -> 발급 -> 로그아웃 or 재로그인
+    // 재로그인 -> 이메일로 유저 찾고 -> 토큰 있으면 이미 있으므로 아무일도 발생 x -> 생성된 리프레시 토큰은 무효화 됨. (이러면 동시접속이 안되는거 한쪽 리프레시는 만료)
+    // 이미 있으면 그걸 반환 할것인가? or 이미 있으면 덮어 씌울것인가?
+    @Transactional
+    public void createRefreshToken(String email, String refreshToken) {
         AppUser appUser = appUserRepository.findByAppUserId(memberRepository.findByEmail(email).getAppUser().getAppUserId());
         Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findByAppUser(appUser);
 
-        //Instant now = Instant.now();
-        //Instant newExpiryDate = now.plus(7, ChronoUnit.DAYS);
+        // Refresh DB에는 토큰 세션은 하나만 유지
+        optionalRefreshToken.ifPresent(token -> deleteByRefreshToken(token.getRefreshToken()));
 
-        if (optionalRefreshToken.isEmpty()) {
-            RefreshToken newRefreshToken = new RefreshToken();
-            newRefreshToken.setAppUser(appUser);
-            newRefreshToken.setRefreshToken(refreshToken);
-            newRefreshToken.setExpiryDate(Instant.now().plus(7, ChronoUnit.DAYS));
+        RefreshToken newRefreshToken = new RefreshToken();
+        newRefreshToken.setAppUser(appUser);
+        newRefreshToken.setRefreshToken(refreshToken);
+        newRefreshToken.setExpiryDate(Instant.now().plus(7, ChronoUnit.DAYS));
 
-            refreshTokenRepository.save(newRefreshToken);
-        } else {
-            //long daysLeft = ChronoUnit.DAYS.between(now, optionalRefreshToken.get().getExpiryDate());
-
-            optionalRefreshToken.get().setRefreshToken(refreshToken);
-            optionalRefreshToken.get().setExpiryDate(Instant.now().plus(7, ChronoUnit.DAYS));
-
-            refreshTokenRepository.save(optionalRefreshToken.get());
-        }
+        refreshTokenRepository.save(newRefreshToken);
     }
 
     public AppUser validateRefreshToken(String refreshToken) {
@@ -58,5 +59,32 @@ public class RefreshTokenService {
     public void deleteByRefreshToken(String refreshToken) {
         RefreshToken targetRefreshToken = refreshTokenRepository.findByRefreshToken(refreshToken);
         refreshTokenRepository.delete(targetRefreshToken);
+    }
+
+    public boolean updateRefreshToken(HttpServletResponse response, String refreshToken) {
+        RefreshToken stringToRefreshToken = refreshTokenRepository.findByRefreshToken(refreshToken);
+        if (stringToRefreshToken == null) return false; // 리프레시 소멸 -> 이미 로그아웃 된 사용자인 경우
+
+        AppUser tokenUser = stringToRefreshToken.getAppUser();
+
+        long daysLeft = ChronoUnit.DAYS.between(Instant.now(), stringToRefreshToken.getExpiryDate());
+        if (daysLeft < MAX_DAYS) {
+            String newRefreshToken = jwtUtil.generateRefreshToken(tokenUser.getMember().getEmail());
+
+            stringToRefreshToken.setRefreshToken(newRefreshToken);
+            stringToRefreshToken.setExpiryDate(Instant.now().plus(7, ChronoUnit.DAYS));
+            refreshTokenRepository.save(stringToRefreshToken);
+
+            ResponseCookie newCookie = ResponseCookie.from("refreshToken", newRefreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .maxAge(7 * 24 * 60 * 60)
+                .build();
+            response.setHeader(HttpHeaders.SET_COOKIE, newCookie.toString());
+        }
+
+        return true;
     }
 }

--- a/src/main/java/com/example/tabi/login/UsernamePasswordJwtLoginFilter.java
+++ b/src/main/java/com/example/tabi/login/UsernamePasswordJwtLoginFilter.java
@@ -18,14 +18,14 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import java.io.IOException;
 
 @Slf4j
-public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+public class UsernamePasswordJwtLoginFilter extends UsernamePasswordAuthenticationFilter {
     private final AuthenticationManager authenticationManager;
     private final JwtUtil jwtUtil;
     private final RefreshTokenService refreshTokenService;
 
-     public JwtAuthenticationFilter(AuthenticationManager authManager,
-                                   JwtUtil jwtUtil,
-                                   RefreshTokenService refreshSvc) {
+     public UsernamePasswordJwtLoginFilter(AuthenticationManager authManager,
+                                           JwtUtil jwtUtil,
+                                           RefreshTokenService refreshSvc) {
         this.authenticationManager = authManager;
         this.jwtUtil = jwtUtil;
         this.refreshTokenService = refreshSvc;
@@ -50,7 +50,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         String accessToken = jwtUtil.generateAccessToken(email);
         String refreshToken = jwtUtil.generateRefreshToken(email);
 
-        refreshTokenService.createOrUpdateToken(email, refreshToken);
+        refreshTokenService.createRefreshToken(email, refreshToken);
 
         response.setHeader("Authorization", "Bearer " + accessToken);
 

--- a/src/main/java/com/example/tabi/login/controller/AuthController.java
+++ b/src/main/java/com/example/tabi/login/controller/AuthController.java
@@ -1,0 +1,160 @@
+package com.example.tabi.login.controller;
+
+import com.example.tabi.appuser.entity.AppUser;
+import com.example.tabi.login.JwtUtil;
+import com.example.tabi.login.RefreshTokenService;
+import com.example.tabi.login.vo.LoginRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.WebUtils;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Auth", description = "인증 관련 API")
+public class AuthController {
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenService refreshTokenService;
+
+    @Operation(
+      summary = "액세스 토큰 갱신",
+      description = "액세스 토큰 만료시 HttpOnly 쿠키 refreshToken을 통해 리프레시 토큰을 전달받아, 새로운 액세스 토큰을 Authorization(Bearer accessToken) 헤더에 담아 응답",
+      parameters = {
+          @Parameter(
+              in = ParameterIn.COOKIE,
+              name = "refreshToken",
+              required = true,
+              description = "리프레시 토큰이 담긴 HttpOnly 쿠키"
+          )
+      },
+      responses = {
+          @ApiResponse(
+              responseCode = "200",
+              description = "새 액세스 토큰 발급 성공",
+              headers = @Header(
+                  name = HttpHeaders.AUTHORIZATION,
+                  description = "Bearer {newAccessToken}"
+              )
+          ),
+          @ApiResponse(
+            responseCode = "401",
+            description = "리프레시 토큰 누락 또는 유효하지 않음"
+          )
+      }
+    )
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshToken(HttpServletRequest request, HttpServletResponse response) {
+        Cookie cookie = WebUtils.getCookie(request, "refreshToken");
+
+        if (cookie == null)
+            return new ResponseEntity<>("No Refresh Token", HttpStatus.UNAUTHORIZED);
+
+        String refreshToken = cookie.getValue();
+
+        AppUser user = refreshTokenService.validateRefreshToken(refreshToken);
+
+        if (user == null)
+            return new  ResponseEntity<>("Invalid Refresh Token", HttpStatus.UNAUTHORIZED);
+
+        String newAccessToken = jwtUtil.generateAccessToken(user.getMember().getEmail());
+        response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + newAccessToken);
+
+        return new ResponseEntity<>("Create New Access Token", HttpStatus.OK);
+    }
+
+    @Operation(
+        summary = "로그아웃",
+        description = "프론트에서는 Access Token을 삭제하고, 해당 주소로 로그아웃 시도",
+        parameters = {
+            @Parameter(
+                    in = ParameterIn.COOKIE,
+                    name = "refreshToken",
+                    required = true,
+                    description = "리프레시 토큰이 담긴 HttpOnly 쿠키"
+            )
+        },
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "로그아웃 성공",
+                headers = {
+                    @Header(name = "Set-Cookie", description = "refreshToken=None;")
+                }
+            ),
+        }
+    )
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout( HttpServletRequest request, HttpServletResponse response) {
+        String accessToken = null;
+        String header = request.getHeader("Authorization");
+
+        if (header != null && header.startsWith("Bearer ")) {
+            accessToken = header.substring(7); // "Bearer " 이후 토큰만 추출
+        }
+
+        Cookie cookie = WebUtils.getCookie(request, "refreshToken");
+        if (cookie != null) {
+            String refreshToken = cookie.getValue();
+            refreshTokenService.deleteByRefreshToken(refreshToken);
+        }
+
+        ResponseCookie expired = ResponseCookie.from("refreshToken", "")
+            .httpOnly(true)
+            .secure(true)
+            .sameSite("None")
+            .path("/")
+            .maxAge(0)
+            .build();
+        response.setHeader(HttpHeaders.SET_COOKIE, expired.toString());
+
+        return new ResponseEntity<>("Success Logout", HttpStatus.OK);
+    }
+
+    @Operation(
+        summary = "로그인",
+        description = "아이디/비밀번호로 로그인하고, 성공 시 Authorization 헤더(Bearer accessToken)와 HttpOnly 쿠키(refreshToken)를 발급",
+        requestBody = @RequestBody(
+            required = true,
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = LoginRequest.class)
+            )
+        ),
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "로그인 성공",
+                headers = {
+                    @Header(name = HttpHeaders.AUTHORIZATION, description = "Bearer {accessToken}"),
+                    @Header(name = "Set-Cookie", description = "refreshToken={refreshToken};")
+                }
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 실패(잘못된 아이디/비번)")
+        }
+    )
+    @PostMapping("/login")
+    // 문서용 api
+    public ResponseEntity<Void> loginDoc() {
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/tabi/login/vo/LoginRequest.java
+++ b/src/main/java/com/example/tabi/login/vo/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.example.tabi.login.vo;
+
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/example/tabi/member/entity/Member.java
+++ b/src/main/java/com/example/tabi/member/entity/Member.java
@@ -1,0 +1,19 @@
+package com.example.tabi.member.entity;
+
+import com.example.tabi.appuser.entity.AppUser;
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity
+@Data
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long memberId;
+    private String email;
+    private String password;
+
+    @OneToOne
+    @JoinColumn(name = "app_user_id")
+    private AppUser appUser;
+}

--- a/src/main/java/com/example/tabi/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/tabi/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.example.tabi.member.repository;
+
+import com.example.tabi.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member,Long> {
+    Member findByEmail(String email);
+}

--- a/src/main/java/com/example/tabi/member/vo/MemberDto.java
+++ b/src/main/java/com/example/tabi/member/vo/MemberDto.java
@@ -1,0 +1,17 @@
+package com.example.tabi.member.vo;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberDto {
+    private Long memberId;
+    private String email;
+    private String password;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,13 @@
 spring.application.name=tabi
+
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+jwt.access.secret.key=${ACCESS_SECRET_KEY}
+jwt.refresh.secret.key=${REFRESH_SECRET_KEY}


### PR DESCRIPTION
1. 앱으로 사용되기 때문에, Refresh Token의 만료시간을 사용자의 접속에 따라 연장시키는 기법이 필요
-> Sliding Expiration을 사용해서 Access Token 재발급시 Refresh Token도 연장(새로 발급, 만료 하루전에만 재발급)
2. 로그아웃 로직은 인증로직을 거친 후 로그아웃 가능
-> 악의적 사용자의 로그아웃 방지