### PR TITLE
[BUGFIX] - Refresh Token Delete Error

### DIFF
--- a/src/main/java/com/example/tabi/login/RefreshTokenService.java
+++ b/src/main/java/com/example/tabi/login/RefreshTokenService.java
@@ -6,6 +6,7 @@ import com.example.tabi.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class RefreshTokenService {
     private final JwtUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository;
@@ -59,6 +61,8 @@ public class RefreshTokenService {
     public void deleteByRefreshToken(String refreshToken) {
         RefreshToken targetRefreshToken = refreshTokenRepository.findByRefreshToken(refreshToken);
         refreshTokenRepository.delete(targetRefreshToken);
+        refreshTokenRepository.flush();
+        log.info("delete successful");
     }
 
     public boolean updateRefreshToken(HttpServletResponse response, String refreshToken) {


### PR DESCRIPTION
재로그인시 원래 리프레시 토큰이 삭제되지 않고 삽입되는 문제 발생
(같은 트랜잭션 내에서 delete -> insert 사용시 delete 쿼리 날라가지 않는 문제 발생)

해결 방법
1. flush 함수를 써서 delete반영후에 insert 하도록 수정